### PR TITLE
Fix bug using shell (FORMAT_DB_DATETIME)

### DIFF
--- a/src/Shell/CacheShell.php
+++ b/src/Shell/CacheShell.php
@@ -36,7 +36,7 @@ class CacheShell extends Shell {
 		$cacheInfo = $cache->extractCacheInfo($content);
 		$time = $cacheInfo['time'];
 		if ($time) {
-			$time = date(FORMAT_DB_DATETIME, $time);
+			$time = date('Y-m-d H:i:s', $time);
 		} else {
 			$time = '(unlimited)';
 		}


### PR DESCRIPTION
The FORMAT_DB_DATETIME variable is not set anywhere in CakePhp nor CakePhpCache. Using the CakePhpCache shell yields an error. This commit corrects that.
