### PR TITLE
Implementing cache expiration check

### DIFF
--- a/src/Routing/Filter/CacheFilter.php
+++ b/src/Routing/Filter/CacheFilter.php
@@ -61,6 +61,15 @@ class CacheFilter extends DispatcherFilter {
 			return;
 		}
 
+		$content = file_get_contents($file);
+		$cacheInfo = $this->extractCacheInfo($content);
+		$cacheTime = $cacheInfo['time'];
+		
+		if ($cacheTime < time() && $cacheTime != 0) {
+			unlink($file);
+			return;
+		}
+
 		$response = $event->data['response'];
 		$event->stopPropagation();
 


### PR DESCRIPTION
There was no way to effectively expire a cached file. This commit adds a check on the cachetime parameter of the file. If the cache has expired (and is not infinite), the file must be deleted and a new version must be retrieved to be cached again.

Related issue: #4 
