### PR TITLE
Remove basepath from cachefile name

### DIFF
--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -86,6 +86,7 @@ class CacheComponent extends Component {
 		}
 
 		$path = $this->request->here();
+        $path = str_replace($this->request->base, '', $path);
 		if ($path === '/') {
 			$path = 'home';
 		}

--- a/src/Routing/Filter/CacheFilter.php
+++ b/src/Routing/Filter/CacheFilter.php
@@ -54,6 +54,7 @@ class CacheFilter extends DispatcherFilter {
 		$request = $event->data['request'];
 
 		$url = $request->here();
+        $url = str_replace($request->base, '', $url);
 		$file = $this->getFile($url);
 
 		if ($file === null) {

--- a/tests/TestCase/Controller/Component/CacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CacheComponentTest.php
@@ -36,6 +36,29 @@ class CacheComponentTest extends TestCase {
 		unset($this->Controller);
 	}
 
+    public function testFileFromSubdirection() {
+        $this->Controller->request->url = 'pages/view/1';
+        $this->Controller->request->base = '/myapp';
+        $this->Controller->request->webroot = '/myapp/';
+        $this->Controller->request->here = '/myapp/pages/view/1';
+
+        $this->Controller->response = $this->getMock('Cake\Network\Response', ['body', 'type']);
+
+        $this->Controller->response->expects($this->once())
+            ->method('body')
+            ->will($this->returnValue('Foo bar'));
+        $this->Controller->response->expects($this->once())
+            ->method('type')
+            ->will($this->returnValue('application/json'));
+
+        $event = new Event('Controller.shutdown', $this->Controller);
+        $this->Controller->Cache->shutdown($event);
+        $file = CACHE . 'views' . DS . 'pages-view-1.html';
+        $this->assertEquals(is_file($file), true);
+
+        unlink($file);
+    }
+
 	/**
 	 * @return void
 	 */


### PR DESCRIPTION
Removing basepath from the filename when working with subdirectories.
