### PR TITLE
Backport keyGenerator from 4.x branch

### DIFF
--- a/docs/Full-page.md
+++ b/docs/Full-page.md
@@ -21,8 +21,8 @@ public function middleware($middlewareQueue) {
             'when' => function (ServerRequest $request, Response $response) {
                 return $request->is('get');
             },
-            'keyGenerator' => function ($key) {
-                return $key; 
+            'keyGenerator' => function ($key, $prefix) {
+                // Implement
             }
         ]))
 
@@ -33,7 +33,7 @@ public function middleware($middlewareQueue) {
 ```
 By adding the `'when'` part, we make sure it only get's invoked for GET requests which is a performance increase.
 
-If you want to create the key used to save the cached file yourself then pass a `'keyGenerator'` callable. This is usefull to remove query keys wich don't affect the page's content.
+If you want to create the key used to save the cached file yourself then pass a `'keyGenerator'` callable. This is useful to e.g. remove query keys which don't affect the page's content.
 
 ### DispatcherFilter
 Your bootstrap needs to enable the Cache dispatcher filter:

--- a/docs/Full-page.md
+++ b/docs/Full-page.md
@@ -21,6 +21,9 @@ public function middleware($middlewareQueue) {
             'when' => function (ServerRequest $request, Response $response) {
                 return $request->is('get');
             },
+            'keyGenerator' => function ($key) {
+                return $key; 
+            }
         ]))
 
         ...
@@ -29,6 +32,8 @@ public function middleware($middlewareQueue) {
 }
 ```
 By adding the `'when'` part, we make sure it only get's invoked for GET requests which is a performance increase.
+
+If you want to create the key used to save the cached file yourself then pass a `'keyGenerator'` callable. This is usefull to remove query keys wich don't affect the page's content.
 
 ### DispatcherFilter
 Your bootstrap needs to enable the Cache dispatcher filter:

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -97,19 +97,20 @@ class CacheComponent extends Component {
 		}
 
 		$keyGenerator = Configure::read('Cache.keyGenerator');
-        if ($keyGenerator) {
-            $url = $keyGenerator($url);
-        }
-
-        $cache = $url;
-
 		$prefix = Configure::read('Cache.prefix');
-		if ($prefix) {
-			$cache = $prefix . '_' . $url;
-		}
 
-		if ($url !== '_root') {
-			$cache = Inflector::slug($cache);
+        if ($keyGenerator) {
+            $cache = $keyGenerator($url, $prefix);
+        } else {
+			$cache = $url;
+
+			if ($prefix) {
+				$cache = $prefix . '_' . $url;
+			}
+
+			if ($url !== '_root') {
+				$cache = Inflector::slug($cache);
+			}
 		}
 
 		if (empty($cache)) {

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -108,7 +108,9 @@ class CacheComponent extends Component {
 			$cache = $prefix . '_' . $url;
 		}
 
-		$cache = Inflector::slug($cache);
+		if ($url !== '_root') {
+			$path = Inflector::slug($path);
+		}
 
 		if (empty($cache)) {
 			return false;

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -109,7 +109,7 @@ class CacheComponent extends Component {
 		}
 
 		if ($url !== '_root') {
-			$path = Inflector::slug($path);
+			$cache = Inflector::slug($cache);
 		}
 
 		if (empty($cache)) {

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -54,12 +54,13 @@ class CacheComponent extends Component {
 	 * @return bool|int|string
 	 */
 	protected function _isActionCachable() {
+		if (!$this->getController()->getRequest()->is('get')) {
+			return false;
+		}
+
 		$actions = $this->getConfig('actions');
 		if (!$actions) {
 			return true;
-		}
-		if (!$this->getController()->getRequest()->is('get')) {
-			return false;
 		}
 
 		$action = $this->getController()->getRequest()->getParam('action');
@@ -99,9 +100,9 @@ class CacheComponent extends Component {
 		$keyGenerator = Configure::read('Cache.keyGenerator');
 		$prefix = Configure::read('Cache.prefix');
 
-        if ($keyGenerator) {
-            $cache = $keyGenerator($url, $prefix);
-        } else {
+		if ($keyGenerator) {
+			$cache = $keyGenerator($url, $prefix);
+		} else {
 			$cache = $url;
 
 			if ($prefix) {

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -96,14 +96,20 @@ class CacheComponent extends Component {
 			$url = '_root';
 		}
 
-		$cache = $url;
+		$keyGenerator = Configure::read('Cache.keyGenerator');
+        if ($keyGenerator) {
+            $url = $keyGenerator($url);
+        }
+
+        $cache = $url;
+
 		$prefix = Configure::read('Cache.prefix');
 		if ($prefix) {
 			$cache = $prefix . '_' . $url;
 		}
-		if ($url !== '_root') {
-			$cache = Inflector::slug($cache);
-		}
+
+		$cache = Inflector::slug($cache);
+
 		if (empty($cache)) {
 			return false;
 		}

--- a/src/Routing/Filter/CacheFilter.php
+++ b/src/Routing/Filter/CacheFilter.php
@@ -112,7 +112,7 @@ class CacheFilter extends DispatcherFilter {
 			$url = '_root';
 		}
 
-		if($keyGenerator){
+		if ($keyGenerator) {
 			$url = $keyGenerator($url);
 		}
 
@@ -122,7 +122,9 @@ class CacheFilter extends DispatcherFilter {
 			$path = $prefix . '_' . $path;
 		}
 
-		$path = Inflector::slug($path);
+		if ($url !== '_root') {
+			$path = Inflector::slug($path);
+		}
 
 		$folder = CACHE . 'views' . DS;
 		$file = $folder . $path . '.html';

--- a/src/Routing/Filter/CacheFilter.php
+++ b/src/Routing/Filter/CacheFilter.php
@@ -114,7 +114,7 @@ class CacheFilter extends DispatcherFilter {
 		$prefix = Configure::read('Cache.prefix');
 		$keyGenerator = Configure::read('Cache.keyGenerator');
 
-		if ($keyGenerator){
+		if ($keyGenerator) {
 			$path = $keyGenerator($url, $prefix);
 		} else {
 			$path = $url;

--- a/src/Routing/Filter/CacheFilter.php
+++ b/src/Routing/Filter/CacheFilter.php
@@ -69,8 +69,7 @@ class CacheFilter extends DispatcherFilter {
 
 		$url = $request->here();
 		$url = str_replace($request->base, '', $url);
-		$keyGenerator = Configure::read('Cache.keyGenerator');
-		$file = $this->getFile($url, $keyGenerator);
+		$file = $this->getFile($url);
 
 		if ($file === null) {
 			return null;
@@ -107,28 +106,30 @@ class CacheFilter extends DispatcherFilter {
 	 *
 	 * @return string|null
 	 */
-	public function getFile($url, $keyGenerator) {
+	public function getFile($url, $mustExist = true) {
 		if ($url === '/') {
 			$url = '_root';
 		}
 
-		if ($keyGenerator) {
-			$url = $keyGenerator($url);
-		}
-
-		$path = $url;
 		$prefix = Configure::read('Cache.prefix');
-		if ($prefix) {
-			$path = $prefix . '_' . $path;
-		}
+		$keyGenerator = Configure::read('Cache.keyGenerator');
 
-		if ($url !== '_root') {
-			$path = Inflector::slug($path);
+		if ($keyGenerator){
+			$path = $keyGenerator($url, $prefix);
+		} else {
+			$path = $url;
+			if ($prefix) {
+				$path = $prefix . '_' . $path;
+			}
+
+			if ($url !== '_root') {
+				$path = Inflector::slug($path);
+			}
 		}
 
 		$folder = CACHE . 'views' . DS;
 		$file = $folder . $path . '.html';
-		if (!file_exists($file)) {
+		if ($mustExist && !file_exists($file)) {
 			return null;
 		}
 		return $file;

--- a/src/Routing/Filter/CacheFilter.php
+++ b/src/Routing/Filter/CacheFilter.php
@@ -69,7 +69,8 @@ class CacheFilter extends DispatcherFilter {
 
 		$url = $request->here();
 		$url = str_replace($request->base, '', $url);
-		$file = $this->getFile($url);
+		$keyGenerator = Configure::read('Cache.keyGenerator');
+		$file = $this->getFile($url, $keyGenerator);
 
 		if ($file === null) {
 			return null;
@@ -106,9 +107,13 @@ class CacheFilter extends DispatcherFilter {
 	 *
 	 * @return string|null
 	 */
-	public function getFile($url, $mustExist = true) {
+	public function getFile($url, $keyGenerator) {
 		if ($url === '/') {
 			$url = '_root';
+		}
+
+		if($keyGenerator){
+			$url = $keyGenerator($url);
 		}
 
 		$path = $url;
@@ -117,13 +122,11 @@ class CacheFilter extends DispatcherFilter {
 			$path = $prefix . '_' . $path;
 		}
 
-		if ($url !== '_root') {
-			$path = Inflector::slug($path);
-		}
+		$path = Inflector::slug($path);
 
 		$folder = CACHE . 'views' . DS;
 		$file = $folder . $path . '.html';
-		if ($mustExist && !file_exists($file)) {
+		if (!file_exists($file)) {
 			return null;
 		}
 		return $file;

--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -115,7 +115,9 @@ class CacheMiddleware {
 			$path = $prefix . '_' . $path;
 		}
 
-		$path = Inflector::slug($path);
+		if ($url !== '_root') {
+			$path = Inflector::slug($path);
+		}
 
 		$folder = CACHE . 'views' . DS;
 		$file = $folder . $path . '.html';

--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -21,7 +21,7 @@ class CacheMiddleware {
 	protected $_defaultConfig = [
 		'when' => null,
 		'cacheTime' => '+1 day',
-		'keyGenerator' => null
+		'keyGenerator' => null,
 	];
 
 	/**
@@ -39,8 +39,8 @@ class CacheMiddleware {
 	 */
 	public function __construct(array $config = []) {
 		$this->setConfig($config);
-		
-		Configure::write('Cache.keyGenerator', $config['keyGenerator']);
+
+		Configure::write('Cache.keyGenerator', $this->getConfig('keyGenerator'));
 	}
 
 	/**
@@ -107,7 +107,7 @@ class CacheMiddleware {
 		$prefix = Configure::read('Cache.prefix');
 		$keyGenerator = $this->getConfig('keyGenerator');
 
-		if ($keyGenerator){
+		if ($keyGenerator) {
 			$path = $keyGenerator($url, $prefix);
 		} else {
 			$path = $url;

--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -40,7 +40,11 @@ class CacheMiddleware {
 	public function __construct(array $config = []) {
 		$this->setConfig($config);
 
-		Configure::write('Cache.keyGenerator', $this->getConfig('keyGenerator'));
+		if (!Configure::read('Cache.keyGenerator')) {
+			Configure::write('Cache.keyGenerator', $this->getConfig('keyGenerator'));
+		} elseif (!$this->getConfig('keyGenerator')) {
+			$this->setConfig('keyGenerator', Configure::read('Cache.keyGenerator'));
+		}
 	}
 
 	/**

--- a/src/Shell/CacheShell.php
+++ b/src/Shell/CacheShell.php
@@ -33,8 +33,9 @@ class CacheShell extends Shell {
 			return;
 		}
 
+		$keyGenerator = Configure::read('Cache.keyGenerator');
 		$cache = new CacheFilter();
-		$file = $cache->getFile($url);
+		$file = $cache->getFile($url, $keyGenerator);
 		if (!$file) {
 			$this->abort('No cache file found');
 		}
@@ -59,8 +60,9 @@ class CacheShell extends Shell {
 	 */
 	public function clear($url = null) {
 		if ($url) {
+			$keyGenerator = Configure::read('Cache.keyGenerator');
 			$cache = new CacheFilter();
-			$file = $cache->getFile($url);
+			$file = $cache->getFile($url, $keyGenerator);
 			if (!$file) {
 				$this->abort('No cache file found');
 			}

--- a/src/Shell/CacheShell.php
+++ b/src/Shell/CacheShell.php
@@ -33,9 +33,8 @@ class CacheShell extends Shell {
 			return;
 		}
 
-		$keyGenerator = Configure::read('Cache.keyGenerator');
 		$cache = new CacheFilter();
-		$file = $cache->getFile($url, $keyGenerator);
+		$file = $cache->getFile($url);
 		if (!$file) {
 			$this->abort('No cache file found');
 		}
@@ -60,9 +59,8 @@ class CacheShell extends Shell {
 	 */
 	public function clear($url = null) {
 		if ($url) {
-			$keyGenerator = Configure::read('Cache.keyGenerator');
 			$cache = new CacheFilter();
-			$file = $cache->getFile($url, $keyGenerator);
+			$file = $cache->getFile($url);
 			if (!$file) {
 				$this->abort('No cache file found');
 			}

--- a/tests/TestCase/Controller/Component/CacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CacheComponentTest.php
@@ -3,8 +3,8 @@
 namespace Cache\Test\TestCase\Controller\Component;
 
 use App\Controller\CacheComponentTestController;
-use Cake\Event\Event;
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Http\ServerRequest;
 use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
@@ -46,9 +46,9 @@ class CacheComponentTest extends TestCase {
 	 */
 	public function testAction() {
 		$request = new ServerRequest([
-			'environment' =>[
+			'environment' => [
 				'REQUEST_METHOD' => 'GET',
-			]
+			],
 		]);
 
 		$this->Controller->setRequest($request);
@@ -74,7 +74,7 @@ class CacheComponentTest extends TestCase {
 	 */
 	public function testActionWithCacheTime() {
 		$request = new ServerRequest([
-			'environment' =>[
+			'environment' => [
 				'REQUEST_METHOD' => 'GET',
 			],
 		]);
@@ -187,7 +187,7 @@ class CacheComponentTest extends TestCase {
 	 */
 	public function testActionWithCompress() {
 		$request = new ServerRequest([
-			'environment' =>[
+			'environment' => [
 				'REQUEST_METHOD' => 'GET',
 			],
 		]);
@@ -219,7 +219,7 @@ class CacheComponentTest extends TestCase {
 	 */
 	public function testActionWithCompressCallback() {
 		$request = new ServerRequest([
-			'environment' =>[
+			'environment' => [
 				'REQUEST_METHOD' => 'GET',
 			],
 		]);
@@ -254,9 +254,9 @@ class CacheComponentTest extends TestCase {
 		$request = new ServerRequest([
 			'url' => '/myapp/pages/view/1',
 			'base' => '/myapp',
-			'environment' =>[
+			'environment' => [
 				'REQUEST_METHOD' => 'GET',
-			]
+			],
 		]);
 
 		$this->Controller->setRequest($request);
@@ -279,7 +279,6 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testActionWithNonGet() {
-		
 		$request = new ServerRequest([
 			'environment' => [
 				'REQUEST_METHOD' => 'POST',
@@ -307,7 +306,6 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testActionWithKeyGenerator() {
-		
 		$request = new ServerRequest([
 			'url' => '/pages/view/1',
 			'environment' => [
@@ -343,7 +341,6 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testActionWithPrefix() {
-		
 		$request = new ServerRequest([
 			'url' => '/pages/view/1',
 			'environment' => [

--- a/tests/TestCase/Controller/Component/CacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CacheComponentTest.php
@@ -298,8 +298,6 @@ class CacheComponentTest extends TestCase {
 		$file = CACHE . 'views' . DS . '_root.html';
 
 		$this->assertFileNotExists($file, 'POST should not cache request');
-
-		@unlink($file);
 	}
 
 	/**
@@ -331,10 +329,10 @@ class CacheComponentTest extends TestCase {
 		$file = CACHE . 'views' . DS . 'customKey.html';
 		$this->assertFileExists($file);
 
+		unlink($file);
+
 		$file = CACHE . 'views' . DS . 'pages-view-1.html';
 		$this->assertFileNotExists($file);
-
-		@unlink($file);
 	}
 
 	/**
@@ -364,10 +362,11 @@ class CacheComponentTest extends TestCase {
 		$file = CACHE . 'views' . DS . 'custom-pages-view-1.html';
 		$this->assertFileExists($file);
 
+		unlink($file);
+
 		$file = CACHE . 'views' . DS . 'pages-view-1.html';
 		$this->assertFileNotExists($file);
 
-		@unlink($file);
 	}
 
 	/**

--- a/tests/TestCase/Controller/Component/CacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CacheComponentTest.php
@@ -44,6 +44,13 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testAction() {
+		$request = new ServerRequest([
+			'environment' =>[
+				'REQUEST_METHOD' => 'GET',
+			]
+		]);
+
+		$this->Controller->setRequest($request);
 		$this->Controller->response = $this->getResponseMock(['getBody']);
 
 		$this->Controller->response->expects($this->once())
@@ -65,6 +72,13 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testActionWithCacheTime() {
+		$request = new ServerRequest([
+			'environment' =>[
+				'REQUEST_METHOD' => 'GET',
+			],
+		]);
+
+		$this->Controller->setRequest($request);
 		$this->Controller->Cache->setConfig('duration', DAY);
 		$this->Controller->response = $this->getResponseMock(['getBody']);
 
@@ -90,6 +104,9 @@ class CacheComponentTest extends TestCase {
 	public function testActionWithExt() {
 		$request = new ServerRequest([
 			'url' => '/foo/bar/baz.json?x=y',
+			'environment' => [
+				'REQUEST_METHOD' => 'GET',
+			],
 		]);
 		$this->Controller->setRequest($request);
 		$this->Controller->response = $this->getResponseMock(['getBody', 'getType']);
@@ -168,6 +185,13 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testActionWithCompress() {
+		$request = new ServerRequest([
+			'environment' =>[
+				'REQUEST_METHOD' => 'GET',
+			],
+		]);
+
+		$this->Controller->setRequest($request);
 		$this->Controller->Cache->setConfig('compress', true);
 
 		$this->Controller->response = $this->getResponseMock(['getBody']);
@@ -193,6 +217,13 @@ class CacheComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testActionWithCompressCallback() {
+		$request = new ServerRequest([
+			'environment' =>[
+				'REQUEST_METHOD' => 'GET',
+			],
+		]);
+
+		$this->Controller->setRequest($request);
 		$this->Controller->Cache->setConfig('compress', function ($content) {
 			$content = str_replace('bar', 'b', $content);
 			return $content;
@@ -222,6 +253,9 @@ class CacheComponentTest extends TestCase {
 		$request = new ServerRequest([
 			'url' => '/myapp/pages/view/1',
 			'base' => '/myapp',
+			'environment' =>[
+				'REQUEST_METHOD' => 'GET',
+			]
 		]);
 
 		$this->Controller->setRequest($request);
@@ -238,6 +272,36 @@ class CacheComponentTest extends TestCase {
 		$file = CACHE . 'views' . DS . 'pages-view-1.html';
 		$this->assertFileExists($file);
 		unlink($file);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testActionWithNonGet() {
+		
+		$request = new ServerRequest([
+			'environment' => [
+				'REQUEST_METHOD' => 'POST',
+			],
+		]);
+
+		$this->assertTrue($request->is('POST'));
+
+		$this->Controller->setRequest($request);
+		$this->Controller->response = $this->getResponseMock(['getBody']);
+
+		$this->Controller->response->expects($this->once())
+			->method('getBody')
+			->will($this->returnValue('Foo bar'));
+
+		$event = new Event('Controller.shutdown', $this->Controller);
+		$this->Controller->Cache->shutdown($event);
+
+		$file = CACHE . 'views' . DS . '_root.html';
+
+		$this->assertFileNotExists($file, 'POST should not cache request');
+
+		@unlink($file);
 	}
 
 	/**


### PR DESCRIPTION
I've added the keyGenerator feature from the 4.x branch. It does not do any filename length checks though, this would have to be implemented by the user in the keyGenerator callable.

I've also removed the $mustExist parameter in all the getFile functions as it was never used by any caller.
