### PR TITLE
Fix content-length header

### DIFF
--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -196,7 +196,7 @@ class CacheMiddleware {
 		}
 
 		if (!$compressionEnabled) {
-			$response = $response->withHeader('Content-Length', (string)filesize($file));
+			$response = $response->withHeader('Content-Length', strlen($this->_cacheContent));
 		}
 
 		$cacheContent = $this->_cacheContent;


### PR DESCRIPTION
Before this change, the content-length header was calculated using the filesize. The file had ~36 bytes extra than what was really served and caused some errors if curl was used to request the cached page (cURL error 18: transfer closed with 36 bytes remaining to read)