### PR TITLE
use getConfig to use passed prefix

### DIFF
--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -109,6 +109,9 @@ class CacheMiddleware {
 		}
 
 		$prefix = Configure::read('Cache.prefix');
+        if ($this->getConfig('prefix')) {
+            $prefix = $this->getConfig('prefix');
+        }
 		$keyGenerator = $this->getConfig('keyGenerator');
 
 		if ($keyGenerator) {


### PR DESCRIPTION
When my application sends a prefix from Application middelware(), it is saved in config.
Now you can reuse that saved prefix in getFile() via getConfig