### PR TITLE
Deprecation fixes

### DIFF
--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -46,7 +46,7 @@ class CacheComponent extends Component {
 	 * @param \Cake\Event\EventInterface $event
 	 * @return void
 	 */
-	public function shutdown(EventInterface $event): void {
+	public function afterFilter(EventInterface $event): void {
 		if (Configure::read('debug') && !$this->getConfig('force')) {
 			return;
 		}

--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -101,7 +101,7 @@ class CacheMiddleware implements MiddlewareInterface {
 		$modified = $cacheStart ?: time();
 		/** @var \Cake\Http\Response $response */
 		$response = $response->withModified($modified);
-		if ($response->checkNotModified($request)) {
+		if ($response->isNotModified($request)) {
 			return $response;
 		}
 


### PR DESCRIPTION
Renamed two methods which trigger deprecated warning in newer CakePHP versions.