### PR TITLE
Update Full-page.md

### DIFF
--- a/docs/Full-page.md
+++ b/docs/Full-page.md
@@ -19,7 +19,7 @@ public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue {
 
         // Handle cached files
         ->add(new CacheMiddleware([
-            'when' => function (ServerRequest $request, Response $response) {
+            'when' => function (ServerRequest $request) {
                 // Implement
             },
             'keyGenerator' => function ($key, $prefix) {


### PR DESCRIPTION
A Response object is not sent during the call to the "when" function. This commit removes it from the docs.