### PR TITLE
Type $io property in commands for 5.next compatibility

### DIFF
--- a/src/Command/PageCacheClearCommand.php
+++ b/src/Command/PageCacheClearCommand.php
@@ -14,10 +14,7 @@ use FilesystemIterator;
 
 class PageCacheClearCommand extends Command {
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @param \Cake\Console\Arguments $args

--- a/src/Command/PageCacheStatusCommand.php
+++ b/src/Command/PageCacheStatusCommand.php
@@ -13,10 +13,7 @@ use FilesystemIterator;
 
 class PageCacheStatusCommand extends Command {
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @param \Cake\Console\Arguments $args


### PR DESCRIPTION
## Summary

CakePHP 5.next ([cakephp/cakephp#19280](https://github.com/cakephp/cakephp/pull/19280)) adds a typed `ConsoleIo $io` property on `BaseCommand`. `PageCacheClearCommand` and `PageCacheStatusCommand` redeclared it as untyped (`protected $io;`), which would fatal on 5.next with:

```
Fatal error: Type of ...::$io must be Cake\Console\ConsoleIo
(as in class Cake\Console\BaseCommand)
```

Typing it in the subclasses is invariant with the upcoming parent declaration and fully compatible with 5.x.