### PR TITLE
Validate cache header ext against allow-list and write atomically

### DIFF
--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -135,6 +135,13 @@ class CacheComponent extends Component {
 	}
 
 	/**
+	 * Writes the cache file atomically.
+	 *
+	 * Uses a temp file in the same directory plus `rename()` so concurrent
+	 * readers never observe a torn header (which previously could fall
+	 * through the regex check, return `[]` from `extractCacheInfo()`, and
+	 * result in `cacheTime` parsing to `0` so the file would never expire).
+	 *
 	 * @param string $content
 	 * @param string $cache
 	 *
@@ -149,7 +156,28 @@ class CacheComponent extends Component {
 		$cache .= '.cache';
 		$file = $folder . $cache;
 
-		return (bool)@file_put_contents($file, $content);
+		$tmp = @tempnam($folder, '.cache-tmp-');
+		if ($tmp === false) {
+			return false;
+		}
+
+		$bytes = @file_put_contents($tmp, $content, LOCK_EX);
+		if ($bytes === false || $bytes !== strlen($content)) {
+			@unlink($tmp);
+
+			return false;
+		}
+
+		// Match the permissions file_put_contents would have produced.
+		@chmod($tmp, 0664 & ~umask());
+
+		if (!@rename($tmp, $file)) {
+			@unlink($tmp);
+
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -21,6 +21,28 @@ class CacheMiddleware implements MiddlewareInterface {
 	use InstanceConfigTrait;
 
 	/**
+	 * Allow-list of cache extensions accepted from the on-disk header.
+	 *
+	 * The cache file header is parsed straight into `Response::withType()`,
+	 * so an attacker (or buggy writer) able to control the `ext` token could
+	 * otherwise force an arbitrary `Content-Type`. Only well-known view
+	 * extensions are honored; anything else falls through to the handler.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const ALLOWED_EXTENSIONS = [
+		'html',
+		'json',
+		'xml',
+		'csv',
+		'txt',
+		'rss',
+		'atom',
+		'js',
+		'css',
+	];
+
+	/**
 	 * @var array<string, mixed>
 	 */
 	protected array $_defaultConfig = [
@@ -57,6 +79,11 @@ class CacheMiddleware implements MiddlewareInterface {
 	 * @return \Psr\Http\Message\ResponseInterface
 	 */
 	public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface {
+		// Reset per-instance state so long-lived workers (Swoole, RoadRunner,
+		// FrankenPHP, ReactPHP) don't leak cache content from a prior request.
+		$this->_cacheContent = null;
+		$this->_cacheInfo = null;
+
 		if ($this->getConfig('check') === false || !$request->is('get')) {
 			return $handler->handle($request);
 		}
@@ -160,7 +187,7 @@ class CacheMiddleware implements MiddlewareInterface {
 
 		$cacheStart = $cacheEnd = 0;
 		$cacheExt = 'html';
-		$this->_cacheContent = preg_replace_callback('/^<!--cachetime:(\d+)\/(\d+);ext:(\w+)-->/', function ($matches) use (&$cacheStart, &$cacheEnd, &$cacheExt) {
+		$this->_cacheContent = preg_replace_callback('/^<!--cachetime:(\d+)\/(\d+);ext:([a-z0-9]{1,8})-->/', function ($matches) use (&$cacheStart, &$cacheEnd, &$cacheExt) {
 			$cacheStart = (int)$matches[1];
 			$cacheEnd = (int)$matches[2];
 			$cacheExt = $matches[3];
@@ -169,6 +196,13 @@ class CacheMiddleware implements MiddlewareInterface {
 		}, (string)$this->_cacheContent);
 
 		if (!$cacheStart) {
+			return [];
+		}
+
+		// Reject anything outside the allow-list — prevents an attacker who
+		// can write to the cache directory from forcing an arbitrary
+		// Content-Type via the on-disk header (MIME confusion / XSS).
+		if (!in_array($cacheExt, static::ALLOWED_EXTENSIONS, true)) {
 			return [];
 		}
 

--- a/src/Utility/FileCache.php
+++ b/src/Utility/FileCache.php
@@ -8,6 +8,23 @@ use Cake\Core\Configure;
 class FileCache {
 
 	/**
+	 * Allow-list of cache extensions accepted from the on-disk header.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const ALLOWED_EXTENSIONS = [
+		'html',
+		'json',
+		'xml',
+		'csv',
+		'txt',
+		'rss',
+		'atom',
+		'js',
+		'css',
+	];
+
+	/**
   * The amount of time to browser cache files (which are unlimited).
   */
 	protected string $_cacheTime = '';
@@ -65,7 +82,7 @@ class FileCache {
 
 		$cacheStart = $cacheEnd = 0;
 		$cacheExt = 'html';
-		$content = (string)preg_replace_callback('/^<!--cachetime:(\d+)\/(\d+);ext:(\w+)-->/', function ($matches) use (&$cacheStart, &$cacheEnd, &$cacheExt) {
+		$content = (string)preg_replace_callback('/^<!--cachetime:(\d+)\/(\d+);ext:([a-z0-9]{1,8})-->/', function ($matches) use (&$cacheStart, &$cacheEnd, &$cacheExt) {
 			$cacheStart = (int)$matches[1];
 			$cacheEnd = (int)$matches[2];
 			$cacheExt = $matches[3];
@@ -74,6 +91,10 @@ class FileCache {
 		}, $content);
 
 		if (!$cacheStart) {
+			return [];
+		}
+
+		if (!in_array($cacheExt, static::ALLOWED_EXTENSIONS, true)) {
 			return [];
 		}
 

--- a/tests/TestCase/Routing/Middleware/CacheMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/CacheMiddlewareTest.php
@@ -92,6 +92,38 @@ class CacheMiddlewareTest extends TestCase {
 	}
 
 	/**
+	 * Cache headers with an `ext` outside the allow-list must NOT be honored.
+	 *
+	 * Prevents an attacker (or buggy writer) able to control the cache file
+	 * content from forcing an arbitrary Content-Type via the on-disk header.
+	 *
+	 * @return void
+	 */
+	public function testBasicUrlWithDisallowedExt() {
+		$folder = CACHE . 'views' . DS;
+		$file = $folder . 'testcontroller-testaction-params1-params2-json.cache';
+		// `php` is not in the allow-list — must fall through to the handler.
+		$content = '<!--cachetime:' . (time() - HOUR) . '/0;ext:php-->Foo bar';
+		file_put_contents($file, $content);
+
+		$request = ServerRequestFactory::fromGlobals([
+			'REQUEST_URI' => '/testcontroller/testaction/params1/params2.json',
+			'REQUEST_METHOD' => 'GET',
+		]);
+		$response = new Response();
+
+		$handler = new TestRequestHandler(null, $response);
+		$middleware = new CacheMiddleware();
+		$newResponse = $middleware->process($request, $handler);
+
+		// Falls through to handler → no body, default text/html type.
+		$this->assertSame('text/html', $newResponse->getType());
+		$this->assertSame('', (string)$newResponse->getBody());
+
+		unlink($file);
+	}
+
+	/**
 	 * Tests that post skips
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

Closes two security/correctness gaps in the on-disk cache pipeline.

- **Allow-list the `ext` header token.** `extractCacheInfo()` parsed `<!--cachetime:.../...;ext:...-->` straight from disk and fed the captured `ext` into `Response::withType()`. Anything able to write to `tmp/cache/views/` (a misconfigured `CACHE` constant pointed at a public path, a compromised plugin, a bug elsewhere that let user input control a cache filename) could therefore force an arbitrary `Content-Type` — MIME confusion / XSS surface. The token is now restricted to a fixed list (`html, json, xml, csv, txt, rss, atom, js, css`) and the regex is tightened to `[a-z0-9]{1,8}`. Mirrored in both `CacheMiddleware` and `FileCache` since both share the parser.
- **Atomic writes.** `CacheComponent::_writeFile()` previously did `file_put_contents($file, $content)` with the error-suppressed builtin, no lock, and no temp-file pattern. Under concurrent traffic the middleware could read a half-written file, the regex match would fail, `cacheTime` would parse to `0`, and the torn entry would never be invalidated by `$cacheEnd < time()`. Now writes go through `tempnam()` + `LOCK_EX` + `rename()` (atomic on the same FS).
- **Reset per-request state.** `_cacheContent` / `_cacheInfo` are now cleared at the top of `process()` so long-lived workers (Swoole, RoadRunner, FrankenPHP, ReactPHP) don't leak content from request N into request N+1. Latent today for fpm setups, a correctness landmine for anyone moving to a persistent runtime.

Adds one test — disallowed `ext` in the on-disk header now falls through to the handler.

Local gates: phpunit (27/27), phpstan level 8, phpcs all clean.
