### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Command/PageCacheStatusCommand.php
+++ b/src/Command/PageCacheStatusCommand.php
@@ -87,11 +87,7 @@ class PageCacheStatusCommand extends Command {
 		}
 
 		$time = $cacheInfo['end'];
-		if ($time) {
-			$time = date('Y-m-d H:i:s', $time);
-		} else {
-			$time = '(unlimited)';
-		}
+		$time = $time ? date('Y-m-d H:i:s', $time) : '(unlimited)';
 
 		if (!$engine) {
 			$file = CacheKey::generate($url, Configure::read('CacheConfig.prefix'), Configure::read('CacheConfig.keyGenerator'));

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -93,7 +93,8 @@ class CacheComponent extends Component {
 		if (array_key_exists($action, $actions)) {
 			return $actions[$action];
 		}
-        return in_array($action, $actions, true);
+
+		return in_array($action, $actions, true);
 	}
 
 	/**

--- a/src/Controller/Component/CacheComponent.php
+++ b/src/Controller/Component/CacheComponent.php
@@ -93,11 +93,7 @@ class CacheComponent extends Component {
 		if (array_key_exists($action, $actions)) {
 			return $actions[$action];
 		}
-		if (in_array($action, $actions, true)) {
-			return true;
-		}
-
-		return false;
+        return in_array($action, $actions, true);
 	}
 
 	/**

--- a/src/Routing/Middleware/CacheMiddleware.php
+++ b/src/Routing/Middleware/CacheMiddleware.php
@@ -129,9 +129,7 @@ class CacheMiddleware implements MiddlewareInterface {
 			return $response->withNotModified();
 		}
 
-		$response = $this->_deliverCacheFile($request, $response, $fileContent, $cacheExt);
-
-		return $response;
+		return $this->_deliverCacheFile($request, $response, $fileContent, $cacheExt);
 	}
 
 	/**
@@ -245,7 +243,7 @@ class CacheMiddleware implements MiddlewareInterface {
 		if ($response->getType() === $ext) {
 			$contentType = 'application/octet-stream';
 			$agent = $request->getEnv('HTTP_USER_AGENT');
-			if ($agent && (preg_match('%Opera([/ ])([0-9].[0-9]{1,2})%', $agent) || preg_match('/MSIE ([0-9].[0-9]{1,2})/', $agent))) {
+			if ($agent && (preg_match('%Opera([/ ])([0-9].[0-9]{1,2})%', $agent) || preg_match('/MSIE (\d.\d{1,2})/', $agent))) {
 				$contentType = 'application/octetstream';
 			}
 
@@ -270,10 +268,8 @@ class CacheMiddleware implements MiddlewareInterface {
 		$response = $response->withCache($modifiedTime, $cacheEnd);
 		$response = $response->withType($cacheInfo['ext']);
 
-		if (Configure::read('debug') || $this->getConfig('debug')) {
-			if ($cacheInfo['ext'] === 'html') {
-				$cacheContent = '<!--created:' . date('Y-m-d H:i:s', $modifiedTime) . '-->' . $cacheContent;
-			}
+		if ((Configure::read('debug') || $this->getConfig('debug')) && $cacheInfo['ext'] === 'html') {
+			$cacheContent = '<!--created:' . date('Y-m-d H:i:s', $modifiedTime) . '-->' . $cacheContent;
 		}
 
 		$body = $response->getBody();

--- a/src/Utility/CacheKey.php
+++ b/src/Utility/CacheKey.php
@@ -17,9 +17,9 @@ class CacheKey {
 		if ($keyGenerator) {
 			$cacheKey = $keyGenerator($url, $prefix);
 			// Validate key length for filesystem compatibility (most filesystems have 255 char limit)
-			if (mb_strlen((string) $cacheKey) > 200) {
-				$key = mb_substr((string) $cacheKey, 0, 159);
-				$cacheKey = $key . '_' . sha1(mb_substr((string) $cacheKey, 159));
+			if (mb_strlen((string)$cacheKey) > 200) {
+				$key = mb_substr((string)$cacheKey, 0, 159);
+				$cacheKey = $key . '_' . sha1(mb_substr((string)$cacheKey, 159));
 			}
 
 			return $cacheKey;

--- a/src/Utility/CacheKey.php
+++ b/src/Utility/CacheKey.php
@@ -15,11 +15,11 @@ class CacheKey {
 	 */
 	public static function generate(string $url, ?string $prefix, $keyGenerator = null) {
 		if ($keyGenerator) {
-			$cacheKey = $keyGenerator($url, $prefix);
+			$cacheKey = (string)$keyGenerator($url, $prefix);
 			// Validate key length for filesystem compatibility (most filesystems have 255 char limit)
-			if (mb_strlen((string)$cacheKey) > 200) {
-				$key = mb_substr((string)$cacheKey, 0, 159);
-				$cacheKey = $key . '_' . sha1(mb_substr((string)$cacheKey, 159));
+			if (mb_strlen($cacheKey) > 200) {
+				$key = mb_substr($cacheKey, 0, 159);
+				$cacheKey = $key . '_' . sha1(mb_substr($cacheKey, 159));
 			}
 
 			return $cacheKey;

--- a/src/Utility/CacheKey.php
+++ b/src/Utility/CacheKey.php
@@ -17,19 +17,15 @@ class CacheKey {
 		if ($keyGenerator) {
 			$cacheKey = $keyGenerator($url, $prefix);
 			// Validate key length for filesystem compatibility (most filesystems have 255 char limit)
-			if (mb_strlen($cacheKey) > 200) {
-				$key = mb_substr($cacheKey, 0, 159);
-				$cacheKey = $key . '_' . sha1(mb_substr($cacheKey, 159));
+			if (mb_strlen((string) $cacheKey) > 200) {
+				$key = mb_substr((string) $cacheKey, 0, 159);
+				$cacheKey = $key . '_' . sha1(mb_substr((string) $cacheKey, 159));
 			}
 
 			return $cacheKey;
 		}
 
-		if ($url === '/') {
-			$url = '_root';
-		} else {
-			$url = substr($url, 1);
-		}
+		$url = $url === '/' ? '_root' : substr($url, 1);
 
 		$cacheKey = $url;
 

--- a/src/Utility/Compressor.php
+++ b/src/Utility/Compressor.php
@@ -10,7 +10,7 @@ class Compressor {
 	 */
 	public function compress($content) {
 		// Removes HTML comments (not containing IE conditional comments).
-		$content = (string)preg_replace_callback('/<!--([\\s\\S]*?)-->/', [$this, '_commentIgnore'], $content);
+		$content = (string)preg_replace_callback('/<!--([\\s\\S]*?)-->/', $this->_commentIgnore(...), $content);
 
 		// Remove whitespace
 		$content = (string)preg_replace('/[\s]+/mu', ' ', $content);
@@ -26,7 +26,7 @@ class Compressor {
 	 * @return string
 	 */
 	protected function _commentIgnore(array $m) {
-		return (strpos($m[1], '[') === 0 || strpos($m[1], '<![') !== false) ? $m[0] : '';
+		return (str_starts_with((string) $m[1], '[') || str_contains((string) $m[1], '<![')) ? $m[0] : '';
 	}
 
 }

--- a/src/Utility/Compressor.php
+++ b/src/Utility/Compressor.php
@@ -26,7 +26,7 @@ class Compressor {
 	 * @return string
 	 */
 	protected function _commentIgnore(array $m) {
-		return (str_starts_with((string) $m[1], '[') || str_contains((string) $m[1], '<![')) ? $m[0] : '';
+		return (str_starts_with((string)$m[1], '[') || str_contains((string)$m[1], '<![')) ? $m[0] : '';
 	}
 
 }

--- a/tests/TestCase/Controller/Component/CacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CacheComponentTest.php
@@ -230,7 +230,7 @@ class CacheComponentTest extends TestCase {
 		]);
 
 		$this->Controller->setRequest($request);
-		$this->Controller->Cache->setConfig('compress', function ($content) {
+		$this->Controller->Cache->setConfig('compress', function ($content, $ext) {
 			return str_replace('bar', 'b', $content);
 		});
 

--- a/tests/TestCase/Controller/Component/CacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CacheComponentTest.php
@@ -231,9 +231,7 @@ class CacheComponentTest extends TestCase {
 
 		$this->Controller->setRequest($request);
 		$this->Controller->Cache->setConfig('compress', function ($content) {
-			$content = str_replace('bar', 'b', $content);
-
-			return $content;
+			return str_replace('bar', 'b', $content);
 		});
 
 		$this->Controller->setResponse($this->getResponseMock(['getBody']));

--- a/tests/TestCase/Routing/Middleware/CacheMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/CacheMiddlewareTest.php
@@ -24,7 +24,7 @@ class CacheMiddlewareTest extends TestCase {
 		$middleware = new CacheMiddleware();
 		$newResponse = $middleware->process($request, $handler);
 
-		$this->assertSame($response, $newResponse, (string)$response . ' vs ' . (string)$newResponse);
+		$this->assertSame($response, $newResponse, $response . ' vs ' . $newResponse);
 		$this->assertSame('text/html', $newResponse->getType());
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.